### PR TITLE
Make the speed of the animation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ import to a copy of the library:
 `1` means they spread over an area the size of the screen, `2` twice the size of the
 screen, `0.5` half the size of the screen.
 
+`speed`: speed of the animation, defaults to `1`. `2` plays the very same animation
+twice as fast, `0.5` twice as slow, `0` freezes it. The animation is independent of the
+framerate, so a given speed looks the same on any display.
+
 ### Text
 
 `text`: string of text to display, that particles will flow around

--- a/attractors.js
+++ b/attractors.js
@@ -22,8 +22,8 @@ const REFERENCE_FRAMERATE = 60;
 const REFERENCE_FRAME_DURATION = 1000 / REFERENCE_FRAMERATE;
 
 /**
- * Speed of the particles, in CSS pixels per second. At the reference framerate,
- * this moves a particle by one pixel per frame.
+ * Speed of the particles at `config.speed` 1, in CSS pixels per second.
+ * At the reference framerate, this moves a particle by one pixel per frame.
  */
 const SPEED = REFERENCE_FRAMERATE;
 
@@ -62,6 +62,8 @@ export const DEFAULT_CONFIG = {
   id: 'paint-canvas',
   /** Scale at which particles are initialized, 1 being the size of the screen. */
   init_scale: 1,
+  /** Speed of the animation, 1 being the reference speed. Below 1 is slower, above is faster. */
+  speed: 1,
   text: '',
   text_position_x: 50,
   text_position_y: 33,
@@ -340,12 +342,17 @@ export class Attractors {
     const pointsY = this.#pointsY;
     const total = pointsX.length;
 
-    // Duration of this frame, expressed as a number of reference frames.
-    const elapsed =
+    // Time the piece advances by during this frame: how long the frame lasted,
+    // scaled by the configured speed. Everything below is derived from it, so that
+    // a speed of 2 plays the very same animation twice as fast.
+    const frameDuration =
       this.#lastTimestamp === null
         ? REFERENCE_FRAME_DURATION
         : Math.min(timestamp - this.#lastTimestamp, MAX_FRAME_DURATION);
     this.#lastTimestamp = timestamp;
+    const elapsed = frameDuration * this.config.speed;
+
+    // Duration of this frame, expressed as a number of reference frames.
     const frames = elapsed / REFERENCE_FRAME_DURATION;
 
     // Distance travelled by a particle during this frame.
@@ -372,8 +379,8 @@ export class Attractors {
         const newY = oldY + step * field.x;
 
         // If the field is weak, reduce the probability to draw a shadow. Shadows are
-        // drawn once per frame, so scale it down on displays faster than the reference
-        // framerate, to keep the same amount of shadows per second.
+        // drawn once per frame, so scale it by the time the frame covers, to keep the
+        // same amount of shadows whatever the framerate and the speed.
         this.#drawShadowAtPoint[i] =
           Math.random() <= (field.x * field.x + field.y * field.y) * frames;
 

--- a/main.js
+++ b/main.js
@@ -92,6 +92,7 @@ gui.addColor(config, 'background_color').name('background');
 gui.add(config, 'nb_attractors', 0, 500).name('attractors');
 gui.add(config, 'particule_density', 0, 3000).name('density');
 gui.add(config, 'init_scale', 0.01, 1.5).name('initial scale');
+gui.add(config, 'speed', 0, 5).name('speed');
 gui.add(config, 'nogo_zone').name('no go zone');
 
 const textFolder = gui.addFolder('Text').close();


### PR DESCRIPTION
## Summary

Adds a `speed` config key, defaulting to `1` — the speed the piece has always run at. Below 1 is slower, above is faster, `0` freezes it.

`speed` scales the time each frame advances the animation by, and everything else is derived from that time:

```js
const elapsed = frameDuration * this.config.speed;
```

So it acts as a true fast-forward knob rather than just a step multiplier: at speed 2 the particles travel twice as far **and** twice as many shadows are drawn, producing exactly the render that speed 1 would have reached in twice the time. The framerate-independence from #9 is preserved — a given speed looks the same on any display.

## Changes

- `attractors.js`: new `speed: 1` in `DEFAULT_CONFIG`; `#render()` scales the (clamped) frame duration by it before deriving the step distance and the per-frame probabilities.
- `main.js`: "speed" slider (0–5) in the control panel, next to "initial scale", so it is shared through the URL like every other setting.
- `README.md`: documented under the particles section.

## Verification

Distance travelled per particle over 2 simulated seconds, driving the render loop with a fake `requestAnimationFrame` clock:

| speed | 30 fps | 60 fps | 120 fps |
|---|---|---|---|
| default | 120 | 119 | 120 |
| 0 | 0 | 0 | 0 |
| 0.5 | 60 | 59.5 | 60 |
| 1 | 120 | 119 | 120 |
| 2 | 240 | 238 | 240 |
| 3 | 360 | 357 | 360 |

Linear in `speed`, flat across framerates, and the default is unchanged.

Also loaded the real page at speed 1 and 3 in a browser: no console errors, the slider appears, the value round-trips through the URL hash, and the render at speed 3 after 3 s looks like the usual piece at ~9 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVHkDkmYbnrBoLTkatmziW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVHkDkmYbnrBoLTkatmziW)_