### PR TITLE
Add fallback glyphs for triangle and hexagon characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ framerate, so a given speed looks the same on any display.
 
 ### Text
 
-`text`: string of text to display, that particles will flow around
+`text`: string of text to display, that particles will flow around. The font has no glyph
+for `▲`, so the library draws it itself, as an equilateral triangle as tall as a capital
+letter
 
 `text_position_x`, `text_position_y`: position of the text, in percent of the canvas
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ framerate, so a given speed looks the same on any display.
 ### Text
 
 `text`: string of text to display, that particles will flow around. The font has no glyph
-for `▲`, so the library draws it itself, as an equilateral triangle as tall as a capital
-letter
+for `▲` and `⬣`, so the library draws them itself, as a triangle and a hexagon as tall as
+a capital letter
 
 `text_position_x`, `text_position_y`: position of the text, in percent of the canvas
 

--- a/attractors.js
+++ b/attractors.js
@@ -47,30 +47,62 @@ const SUBDIVISE_NOGO = 16;
 
 const FONT = 'fonts/CamBam/1CamBam_Stick_2.ttf';
 
+/** Draws a closed outline through the given `[x, y]` points. */
+function polygon(path, points) {
+  path.moveTo(...points[0]);
+  for (const point of points.slice(1)) {
+    path.lineTo(...point);
+  }
+  // Come back to the first point explicitly: a closing "Z" command creates no attractor,
+  // so without this line the last side would attract nothing.
+  path.lineTo(...points[0]);
+  path.close();
+}
+
+/**
+ * Width of a fallback glyph, in font units. Both the triangle and the hexagon are
+ * regular polygons fitting in the cap height, hence `2 / sqrt(3)` as wide as they are tall.
+ */
+function polygonWidth(capHeight) {
+  return (2 / Math.sqrt(3)) * capHeight;
+}
+
 /**
  * Characters that the fonts have no glyph for, drawn by the library instead.
- * Their outline is built from the font's cap height, so that they sit on the baseline
- * and match the size of the letters around them.
+ * `outline(path, capHeight, x)` draws the character starting at `x`, on the baseline and
+ * as tall as a capital letter, so that it matches the letters around it. It returns the
+ * width it drew, in font units.
  */
 const FALLBACK_GLYPHS = [
   {
-    /** ▲ BLACK UP-POINTING TRIANGLE. */
+    /** ▲ BLACK UP-POINTING TRIANGLE: an equilateral triangle standing on the baseline. */
     unicode: 0x25b2,
     name: 'blackuptriangle',
-    /**
-     * Draws an equilateral triangle as tall as a capital letter.
-     * @returns {number} The advance width of the glyph, in font units.
-     */
-    outline(path, capHeight, sideBearing) {
-      const side = (2 / Math.sqrt(3)) * capHeight;
-      path.moveTo(sideBearing + side / 2, capHeight);
-      path.lineTo(sideBearing + side, 0);
-      path.lineTo(sideBearing, 0);
-      // Come back to the apex explicitly: a closing "Z" command creates no attractor,
-      // so without this line the third side would attract nothing.
-      path.lineTo(sideBearing + side / 2, capHeight);
-      path.close();
-      return side + 2 * sideBearing;
+    outline(path, capHeight, x) {
+      const width = polygonWidth(capHeight);
+      polygon(path, [
+        [x + width / 2, capHeight],
+        [x + width, 0],
+        [x, 0],
+      ]);
+      return width;
+    },
+  },
+  {
+    /** ⬣ HORIZONTAL BLACK HEXAGON: a regular hexagon lying on a flat side. */
+    unicode: 0x2b23,
+    name: 'horizontalblackhexagon',
+    outline(path, capHeight, x) {
+      const width = polygonWidth(capHeight);
+      polygon(path, [
+        [x, capHeight / 2],
+        [x + width / 4, capHeight],
+        [x + (3 * width) / 4, capHeight],
+        [x + width, capHeight / 2],
+        [x + (3 * width) / 4, 0],
+        [x + width / 4, 0],
+      ]);
+      return width;
     },
   },
 ];
@@ -190,7 +222,7 @@ function addFallbackGlyphs(font, { Glyph, Path }) {
     }
 
     const path = new Path();
-    const advanceWidth = outline(path, height, sideBearing);
+    const advanceWidth = outline(path, height, sideBearing) + 2 * sideBearing;
     const index = font.glyphs.length;
     font.glyphs.push(index, new Glyph({ name, unicode, index, advanceWidth, path }));
     glyphIndexMap[unicode] = index;

--- a/attractors.js
+++ b/attractors.js
@@ -48,6 +48,37 @@ const SUBDIVISE_NOGO = 16;
 const FONT = 'fonts/CamBam/1CamBam_Stick_2.ttf';
 
 /**
+ * Characters that the fonts have no glyph for, drawn by the library instead.
+ * Their outline is built from the font's cap height, so that they sit on the baseline
+ * and match the size of the letters around them.
+ */
+const FALLBACK_GLYPHS = [
+  {
+    /** ▲ BLACK UP-POINTING TRIANGLE. */
+    unicode: 0x25b2,
+    name: 'blackuptriangle',
+    /**
+     * Draws an equilateral triangle as tall as a capital letter.
+     * @returns {number} The advance width of the glyph, in font units.
+     */
+    outline(path, capHeight, sideBearing) {
+      const side = (2 / Math.sqrt(3)) * capHeight;
+      path.moveTo(sideBearing + side / 2, capHeight);
+      path.lineTo(sideBearing + side, 0);
+      path.lineTo(sideBearing, 0);
+      // Come back to the apex explicitly: a closing "Z" command creates no attractor,
+      // so without this line the third side would attract nothing.
+      path.lineTo(sideBearing + side / 2, capHeight);
+      path.close();
+      return side + 2 * sideBearing;
+    },
+  },
+];
+
+/** Side bearing of the fallback glyphs, as a fraction of the em square. */
+const FALLBACK_GLYPH_SIDE_BEARING = 0.04;
+
+/**
  * The text that the `cleanPath` command table below was hand-tuned for.
  * When it is rendered, only the listed path commands become attractors.
  */
@@ -129,16 +160,55 @@ function normalRand() {
   }
 }
 
+/** Height of a capital letter of a font, in font units. */
+function getCapHeight(font) {
+  const declared = font.tables.os2?.sCapHeight;
+  if (declared > 0) {
+    return declared;
+  }
+  const { y2 } = font.charToGlyph('A').getBoundingBox();
+  return y2 > 0 && Number.isFinite(y2) ? y2 : 0.7 * font.unitsPerEm;
+}
+
+/**
+ * Adds to a font the glyphs of `FALLBACK_GLYPHS` it does not have, so that the
+ * characters they draw can be used in the text like any other.
+ */
+function addFallbackGlyphs(font, { Glyph, Path }) {
+  const glyphIndexMap = font.tables.cmap?.glyphIndexMap;
+  if (!glyphIndexMap) {
+    return font;
+  }
+
+  const height = getCapHeight(font);
+  const sideBearing = FALLBACK_GLYPH_SIDE_BEARING * font.unitsPerEm;
+
+  for (const { unicode, name, outline } of FALLBACK_GLYPHS) {
+    // The font draws this character itself, nothing to add.
+    if (glyphIndexMap[unicode]) {
+      continue;
+    }
+
+    const path = new Path();
+    const advanceWidth = outline(path, height, sideBearing);
+    const index = font.glyphs.length;
+    font.glyphs.push(index, new Glyph({ name, unicode, index, advanceWidth, path }));
+    glyphIndexMap[unicode] = index;
+  }
+
+  return font;
+}
+
 /** Loads and parses a font, memoized by URL. */
 async function loadFont(url) {
   if (!fontCache.has(url)) {
     const promise = (async () => {
-      const { parse } = await import('opentype.js');
+      const opentype = await import('opentype.js');
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`Could not load font ${url}: ${response.status}`);
       }
-      return parse(await response.arrayBuffer());
+      return addFallbackGlyphs(opentype.parse(await response.arrayBuffer()), opentype);
     })();
     fontCache.set(url, promise);
   }

--- a/main.js
+++ b/main.js
@@ -69,7 +69,8 @@ function onKeyDown(event) {
     event.preventDefault();
     config.text = config.text.slice(0, -1);
     reload();
-  } else if (/^[a-zA-Z\s/]$/.test(event.key)) {
+  } else if (event.key.length === 1 && !event.ctrlKey && !event.metaKey) {
+    // Any printable character: keys such as "ArrowLeft" or "F5" have a longer name.
     config.text += event.key;
     reload();
   } else {


### PR DESCRIPTION
## Summary
This PR adds support for displaying triangle (▲) and hexagon (⬣) characters by implementing fallback glyphs when the font doesn't have them. The library now draws these shapes itself as geometric polygons that match the height of capital letters.

## Key Changes
- **New fallback glyph system**: Added `FALLBACK_GLYPHS` array with definitions for `▲` (BLACK UP-POINTING TRIANGLE) and `⬣` (HORIZONTAL BLACK HEXAGON) characters
- **Polygon drawing utility**: Implemented `polygon()` function to draw closed outlines through given points, ensuring proper attractor behavior by explicitly closing paths
- **Font metrics helper**: Added `getCapHeight()` function to determine capital letter height from font tables with fallback logic
- **Glyph injection**: Implemented `addFallbackGlyphs()` to inject missing glyphs into fonts at load time, making fallback characters usable like any other character
- **Improved keyboard input handling**: Changed text input validation from a restrictive regex pattern to a more flexible check that accepts any printable character while filtering out special keys (ArrowLeft, F5, etc.)
- **Documentation**: Updated README to document the fallback glyph feature

## Implementation Details
- Fallback glyphs are regular polygons (equilateral triangle and hexagon) that fit within the cap height for visual consistency with surrounding text
- Side bearing is applied as 4% of the em square to provide proper spacing
- The `polygon()` function explicitly draws a line back to the first point before closing, ensuring the last edge creates proper attractors (SVG's "Z" command alone doesn't create attractors)
- Font loading now passes the opentype module to `addFallbackGlyphs()` to access the `Glyph` and `Path` constructors needed for glyph creation

https://claude.ai/code/session_01T5oV2NCJHJbD1t2cST6yCd